### PR TITLE
Fix preflight 000 RLS query + remove 007 duplicate-index creates

### DIFF
--- a/supabase/updates/000_preflight_report.sql
+++ b/supabase/updates/000_preflight_report.sql
@@ -5,14 +5,18 @@
 -- =============================================================================
 
 -- 1. RLS state of every table in the public schema.
+-- NOTE: pg_tables exposes rowsecurity but NOT forcerowsecurity; both flags live
+-- on pg_class (relrowsecurity / relforcerowsecurity), so query that instead.
 SELECT
-    schemaname,
-    tablename,
-    rowsecurity AS rls_enabled,
-    forcerowsecurity AS rls_forced
-FROM pg_tables
-WHERE schemaname = 'public'
-ORDER BY rowsecurity, tablename;
+    n.nspname AS schemaname,
+    c.relname AS tablename,
+    c.relrowsecurity AS rls_enabled,
+    c.relforcerowsecurity AS rls_forced
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND c.relkind IN ('r', 'p')
+ORDER BY c.relrowsecurity, c.relname;
 
 -- 2. Every policy in the public schema (name, command, roles, expressions).
 SELECT

--- a/supabase/updates/007_indexes_and_keys.sql
+++ b/supabase/updates/007_indexes_and_keys.sql
@@ -48,25 +48,24 @@ DROP INDEX IF EXISTS public.cw_device_owners_permission_level_idx;
 -- ---------------------------------------------------------------------------
 -- B) FK indexes that back real API query patterns
 -- ---------------------------------------------------------------------------
--- Permission scoping: every device read/manage query joins
--- cw_device_owners on (dev_eui, user_id, permission_level) — already covered
--- by idx_cw_device_owners_dev_user_perm — plus per-user listings:
-CREATE INDEX IF NOT EXISTS idx_cw_device_owners_user_id
-    ON public.cw_device_owners (user_id);
+-- NOTE: `CREATE INDEX IF NOT EXISTS` matches on the index *name*, not its
+-- column coverage. The 000 preflight (section 9) confirmed these single-column
+-- indexes ALREADY EXIST under different names, so creating same-coverage
+-- indexes here would re-introduce duplicates — the exact thing section A
+-- removes. They are intentionally omitted (existing index in parentheses):
+--   user_id on cw_device_owners              (idx_cdo_user)
+--   location_id on cw_location_owners        (cw_location_owners_location_id_idx)
+--   user_id on cw_location_owners            (idx_clo_user)
+--   dev_eui on cw_device_report_assignments  (cw_device_report_assignments_dev_eui_idx)
 
--- Location permission scoping and "users in this location" listings:
-CREATE INDEX IF NOT EXISTS idx_cw_location_owners_location_id
-    ON public.cw_location_owners (location_id);
-CREATE INDEX IF NOT EXISTS idx_cw_location_owners_user_id
-    ON public.cw_location_owners (user_id);
-
--- Rule/report template fan-out (rules-new / reports-new modules):
+-- Rule/report template fan-out (rules-new / reports-new modules).
+-- cw_device_rule_assignments has only UNIQUE (dev_eui, template_id) + pkey, so
+-- template_id has no standalone index. (The dev_eui index is prefix-covered by
+-- that unique; kept as a small explicit single-column index.)
 CREATE INDEX IF NOT EXISTS idx_cw_device_rule_assignments_dev_eui
     ON public.cw_device_rule_assignments (dev_eui);
 CREATE INDEX IF NOT EXISTS idx_cw_device_rule_assignments_template_id
     ON public.cw_device_rule_assignments (template_id);
-CREATE INDEX IF NOT EXISTS idx_cw_device_report_assignments_dev_eui
-    ON public.cw_device_report_assignments (dev_eui);
 
 -- Triggered-rule history lookups (rules-new /triggered endpoints):
 CREATE INDEX IF NOT EXISTS idx_cw_rule_trigger_log_template_id
@@ -84,10 +83,6 @@ COMMIT;
 -- ---------------------------------------------------------------------------
 -- Zero-lock alternative for section B (run each alone, outside a transaction):
 -- ---------------------------------------------------------------------------
--- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cw_device_owners_user_id ON public.cw_device_owners (user_id);
--- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cw_location_owners_location_id ON public.cw_location_owners (location_id);
--- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cw_location_owners_user_id ON public.cw_location_owners (user_id);
 -- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cw_device_rule_assignments_dev_eui ON public.cw_device_rule_assignments (dev_eui);
 -- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cw_device_rule_assignments_template_id ON public.cw_device_rule_assignments (template_id);
--- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cw_device_report_assignments_dev_eui ON public.cw_device_report_assignments (dev_eui);
 -- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cw_rule_trigger_log_template_id ON public.cw_rule_trigger_log (template_id);


### PR DESCRIPTION
Follow-up to #64. Two manual `supabase/updates/` scripts had defects surfaced by running `000` against production. Neither had been executed against prod yet (`000` is read-only; `007` not run), so this is a pre-run cleanup. **No application code changes.**

## `000_preflight_report.sql` — section 1 errored
It selected `pg_tables.forcerowsecurity`, which doesn't exist (the view exposes only `rowsecurity`):
```
ERROR: column "forcerowsecurity" does not exist
```
So the RLS-state baseline never got captured. Fixed by querying `pg_class.relrowsecurity` / `relforcerowsecurity` instead (same output columns). Re-run section 1 to capture the pre-`002` baseline.

## `007_indexes_and_keys.sql` — section B re-added 4 duplicates
`CREATE INDEX IF NOT EXISTS` matches on the index **name**, not column coverage. Four of the section-B creates used new names for columns that are **already indexed** under other names (confirmed by the live `000` section-9 output), so they would have re-introduced the very duplicates section A removes:

| removed create | already exists as |
|---|---|
| `idx_cw_device_owners_user_id` | `idx_cdo_user` |
| `idx_cw_location_owners_location_id` | `cw_location_owners_location_id_idx` |
| `idx_cw_location_owners_user_id` | `idx_clo_user` |
| `idx_cw_device_report_assignments_dev_eui` | `cw_device_report_assignments_dev_eui_idx` |

No coverage is lost — each surviving index is untouched by section A. The 3 genuinely-new indexes (`idx_cw_device_rule_assignments_dev_eui`, `idx_cw_device_rule_assignments_template_id`, `idx_cw_rule_trigger_log_template_id`) remain, and the `CONCURRENTLY` alternates were trimmed to match.

## Also verified (no change needed)
`005_function_hardening.sql` already covers every SECURITY DEFINER / unpinned function seen in `000` section 7 (incl. `delete_avatar`, `delete_old_avatar`, `delete_old_profile`, `delete_storage_object`, `get_location_for_user`, and the `get_hloc_data` overloads).

> Note: the separate `permission_level = 255` rows blocking `001` are a **data** issue (handled directly on the DB), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)