### PR TITLE
Fix 006: drop stripe foreign-data wrapper before the wrappers extension

### DIFF
--- a/supabase/updates/006_remove_stripe.sql
+++ b/supabase/updates/006_remove_stripe.sql
@@ -36,8 +36,14 @@ DROP SCHEMA IF EXISTS stripe;
 -- Foreign server + any leftover objects that depend on it.
 DROP SERVER IF EXISTS stripe_server CASCADE;
 
+-- The foreign-data wrapper 'stripe' depends on the wrappers extension's
+-- validator/handler functions (stripe_fdw_validator) and is NOT removed by
+-- dropping the server, so it must be dropped before the extension or
+-- DROP EXTENSION fails with 2BP01 (dependent objects still exist).
+DROP FOREIGN DATA WRAPPER IF EXISTS stripe CASCADE;
+
 -- The wrappers extension only existed for the Stripe FDW; remove it now that
--- no foreign server remains. (Re-installable any time from the dashboard.)
+-- no foreign server or wrapper remains. (Re-installable any time from the dashboard.)
 DROP EXTENSION IF EXISTS wrappers;
 
 COMMIT;


### PR DESCRIPTION
Running `006` in prod threw at `DROP EXTENSION wrappers`:
```
ERROR: cannot drop extension wrappers because other objects depend on it   [2BP01]
Detail: foreign-data wrapper stripe depends on function stripe_fdw_validator(text[],oid)
```

## Cause
`DROP SERVER … CASCADE` removes the server and its foreign tables, but **not** the foreign-data wrapper object `stripe`. That wrapper depends on the `wrappers` extension's validator/handler functions, so `DROP EXTENSION wrappers` still has a dependent and fails. `006` is transactional, so the run rolled back — no changes.

## Fix
Add `DROP FOREIGN DATA WRAPPER IF EXISTS stripe CASCADE;` between `DROP SERVER` and `DROP EXTENSION`, so the full chain unwinds: foreign tables → server → **wrapper** → extension. Pre-checks confirmed `stripe_server` (on the `stripe` FDW) was the only foreign server, so nothing else needs `wrappers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)