### PR TITLE
Document retired Babylon table drops in 008 (commented)

### DIFF
--- a/supabase/updates/008_DESTRUCTIVE_legacy_table_drops.sql
+++ b/supabase/updates/008_DESTRUCTIVE_legacy_table_drops.sql
@@ -55,3 +55,33 @@
 -- DROP TABLE IF EXISTS public.report_user_schedule;
 -- DROP TABLE IF EXISTS public.reports_templates;
 -- DROP TABLE IF EXISTS public.reports;
+
+-- ---------------------------------------------------------------------------
+-- 4) Retired "Babylon" data-routing subsystem
+--    (in_connections -> decoders -> out_connections / notifiers, wired via
+--    input_output). Verified 2026-06-14: ZERO references in the api / CropWatch
+--    / CWUI application code (only the generated database.types.ts lists them),
+--    no views or functions reference them, and the only foreign keys are
+--    internal to the cluster plus two outbound to profiles — nothing OUTSIDE
+--    babylon depends on them. Last row written 2024-07-26 (~2 years stale);
+--    ~44 rows total. babylon_notifiers (0 rows) carried username/password/
+--    api_key columns. All rows are in the pre-rollout backup dump.
+--
+-- SELECT 'babylon_connection_types' AS tbl, count(*) FROM public.babylon_connection_types
+-- UNION ALL SELECT 'babylon_decoders', count(*) FROM public.babylon_decoders
+-- UNION ALL SELECT 'babylon_in_connections', count(*) FROM public.babylon_in_connections
+-- UNION ALL SELECT 'babylon_input_output', count(*) FROM public.babylon_input_output
+-- UNION ALL SELECT 'babylon_notifiers', count(*) FROM public.babylon_notifiers
+-- UNION ALL SELECT 'babylon_notifiers_out_connections', count(*) FROM public.babylon_notifiers_out_connections
+-- UNION ALL SELECT 'babylon_out_connections', count(*) FROM public.babylon_out_connections;
+--
+-- One statement — Postgres resolves the internal FK order; no CASCADE, so it
+-- fails loudly if any external dependency appears before you run it:
+-- DROP TABLE IF EXISTS
+--   public.babylon_input_output,
+--   public.babylon_notifiers_out_connections,
+--   public.babylon_notifiers,
+--   public.babylon_in_connections,
+--   public.babylon_out_connections,
+--   public.babylon_connection_types,
+--   public.babylon_decoders;


### PR DESCRIPTION
Adds **block 4** to `008_DESTRUCTIVE_legacy_table_drops.sql` for the retired **"Babylon"** data-routing subsystem (`babylon_connection_types`, `babylon_decoders`, `babylon_in_connections`, `babylon_input_output`, `babylon_notifiers`, `babylon_notifiers_out_connections`, `babylon_out_connections`).

Like the rest of `008`, it's **fully commented out** — documented for the future destructive-cleanup window, not executed now.

## Why it's safe to drop (verified 2026-06-14)
- **Zero application-code references** in `api`, `CropWatch`, and `CWUI` (`src` greps clean; the only matches are the generated `database.types.ts`).
- **No views or functions** reference any babylon table.
- **Foreign keys are self-contained** — only *between* babylon tables, plus two outbound to `profiles`. **Nothing outside the cluster depends on them.**
- **~44 rows, last write 2024-07-26** (~2 years stale). `babylon_notifiers` is empty but carried `username`/`password`/`api_key` columns — good to retire.
- All rows are captured in the pre-rollout backup dump.

## Contents of the block
- The verification count query (run first).
- An FK-safe single `DROP TABLE` listing all 7 (Postgres resolves internal order; **no `CASCADE`**, so it fails loudly if any external dependency appears before you run it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)