### PR TITLE
fix(build): exclude web/ from nest build (unbreak master CI gate)

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "web", "static", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Why
The post-merge **API CI Gate** on master failed after #74 merged:

```
web/src/main.ts:3 - error TS2307: Cannot find module 'svelte'
web/vite.config.ts:1 - error TS2307: Cannot find module 'vite'
... Found 4 error(s)
```

`nest build` (tsc) was compiling the standalone Vite/Svelte landing page under `web/`, whose deps (`svelte`, `vite`, `@sveltejs/vite-plugin-svelte`) live in `web/node_modules`, not the API's. `web/` builds separately into `static/`, so it must not be part of the API TypeScript build.

## Fix
Add `web` and `static` to `exclude` in `tsconfig.build.json`. Verified locally — `pnpm run build` now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)